### PR TITLE
Removed default text color, fixed DateController initialization

### DIFF
--- a/example/lib/src/widgets/curve_highlight_date_picker.dart
+++ b/example/lib/src/widgets/curve_highlight_date_picker.dart
@@ -7,7 +7,6 @@ class CurveHighlightDatePicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.grey[900],
       appBar: AppBar(
         backgroundColor: Colors.blueAccent,
         title: const Text(

--- a/example/lib/src/widgets/curve_holo_date_picker.dart
+++ b/example/lib/src/widgets/curve_holo_date_picker.dart
@@ -7,7 +7,6 @@ class CurveHoloDatePicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
       appBar: AppBar(
         backgroundColor: Colors.blueAccent,
         title: const Text(

--- a/example/lib/src/widgets/curve_line_date_picker.dart
+++ b/example/lib/src/widgets/curve_line_date_picker.dart
@@ -7,7 +7,6 @@ class CurveLineDatePicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.black,
       appBar: AppBar(
         backgroundColor: Colors.blueAccent,
         title: const Text(

--- a/example/lib/src/widgets/flat_highlight_date_picker.dart
+++ b/example/lib/src/widgets/flat_highlight_date_picker.dart
@@ -7,7 +7,6 @@ class FlatHighlightDatePicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.grey[900],
       appBar: AppBar(
         backgroundColor: Colors.blueAccent,
         title: const Text(

--- a/example/lib/src/widgets/flat_holo_date_picker.dart
+++ b/example/lib/src/widgets/flat_holo_date_picker.dart
@@ -7,7 +7,6 @@ class FlatHoloDatePicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
       appBar: AppBar(
         backgroundColor: Colors.blueAccent,
         title: const Text(

--- a/example/lib/src/widgets/flat_line_date_picker.dart
+++ b/example/lib/src/widgets/flat_line_date_picker.dart
@@ -7,7 +7,6 @@ class FlatLineDatePicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.black,
       appBar: AppBar(
         backgroundColor: Colors.blueAccent,
         title: const Text(

--- a/lib/src/constants/theme_constants.dart
+++ b/lib/src/constants/theme_constants.dart
@@ -17,7 +17,6 @@ const double defaultOpacity = 0.1;
 
 /// Default value of [ScrollWheelDatePicker]'s item textstyle.
 const TextStyle defaultItemTextStyle = TextStyle(
-  color: Colors.white,
   fontWeight: FontWeight.bold,
   fontSize: 18.0,
 );

--- a/lib/src/widgets/scroll_wheel_date_picker.dart
+++ b/lib/src/widgets/scroll_wheel_date_picker.dart
@@ -9,13 +9,13 @@ import 'overlays/holo_overlay.dart';
 import 'overlays/line_overlay.dart';
 import 'overlays/highlight_overlay.dart';
 
-class ScrollWheelDatePicker extends StatelessWidget {
+class ScrollWheelDatePicker extends StatefulWidget {
   /// A scroll wheel date picker that has two types:
   ///
   /// `CurveScrollWheel` - Uses [ListWheelScrollView] to create a date picker with a curve perspective.
   ///
   /// `FlatScrollWheel` - Based on [ListWheelScrollView] to create a date picker with a flat perspective.
-  ScrollWheelDatePicker({
+  const ScrollWheelDatePicker({
     super.key,
     this.initialDate,
     this.startDate,
@@ -26,11 +26,7 @@ class ScrollWheelDatePicker extends StatelessWidget {
     this.onSelectedItemChanged,
     required this.theme,
     this.listenAfterAnimation = true,
-  }) : _dateController = DateController(
-          initialDate: initialDate,
-          startDate: startDate,
-          lastDate: lastDate,
-        );
+  });
 
   /// The initial date for the [ScrollWheelDatePicker]. Defaults to [DateTime.now].
   final DateTime? initialDate;
@@ -41,8 +37,7 @@ class ScrollWheelDatePicker extends StatelessWidget {
   /// Sets the last date for the [ScrollWheelDatePicker]. Defaults to [lastDate].
   final DateTime? lastDate;
 
-  /// Manages the initialization and changes of the [ScrollWheelDatePicker].
-  final DateController _dateController;
+
 
   /// Whether to loop through all of the items in the days scroll wheel. Defaults to `true`.
   final bool loopDays;
@@ -68,52 +63,77 @@ class ScrollWheelDatePicker extends StatelessWidget {
   /// Whether to call the [onSelectedItemChanged] when the scroll wheel animation is completed. Defaults to `true`.
   final bool listenAfterAnimation;
 
-  /// Selects what type of scroll wheel to use based on [theme].
+  @override
+  State<ScrollWheelDatePicker> createState() => _ScrollWheelDatePickerState();
+}
+
+class _ScrollWheelDatePickerState extends State<ScrollWheelDatePicker> {
+  /// Manages the initialization and changes of the [ScrollWheelDatePicker].
+  late final DateController _dateController;
+
+  @override
+  void initState() {
+    _dateController = DateController(
+      initialDate: widget.initialDate,
+      startDate: widget.startDate,
+      lastDate: widget.lastDate,
+    );
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _dateController.dispose();
+    super.dispose();
+  }
+
+
+  /// Selects what type of scroll wheel to use based on [widget.theme].
   Widget _scrollWidget({
     required IDateController controller,
     Function(int value)? controllerItemChanged,
     required bool looping,
   }) {
-    return theme is CurveDatePickerTheme
+    return widget.theme is CurveDatePickerTheme
         ? CurveScrollWheel(
             items: controller.items,
             selectedIndex: controller.selectedIndex,
             onSelectedItemChanged: controllerItemChanged,
             looping: looping,
-            diameterRatio: (theme as CurveDatePickerTheme).diameterRatio,
-            itemExtent: theme.itemExtent,
-            overAndUnderCenterOpacity: theme.overAndUnderCenterOpacity,
-            textStyle: theme.itemTextStyle,
-            listenAfterAnimation: listenAfterAnimation,
+            diameterRatio: (widget.theme as CurveDatePickerTheme).diameterRatio,
+            itemExtent: widget.theme.itemExtent,
+            overAndUnderCenterOpacity: widget.theme.overAndUnderCenterOpacity,
+            textStyle: widget.theme.itemTextStyle,
+            listenAfterAnimation: widget.listenAfterAnimation,
           )
         : FlatScrollWheel(
             items: controller.items,
             selectedIndex: controller.selectedIndex,
             onSelectedItemChanged: controllerItemChanged,
             looping: looping,
-            itemExtent: theme.itemExtent,
-            textStyle: theme.itemTextStyle,
-            listenAfterAnimation: listenAfterAnimation,
+            itemExtent: widget.theme.itemExtent,
+            textStyle: widget.theme.itemTextStyle,
+            listenAfterAnimation: widget.listenAfterAnimation,
           );
   }
 
   /// Selects center overlay base on [ScrollWheelDatePickerOverlay].
   Widget _overlay() {
-    switch (theme.overlay) {
+    switch (widget.theme.overlay) {
       case ScrollWheelDatePickerOverlay.highlight:
         return HightlightOverlay(
-          height: theme.itemExtent,
-          color: theme.overlayColor,
+          height: widget.theme.itemExtent,
+          color: widget.theme.overlayColor,
         );
       case ScrollWheelDatePickerOverlay.holo:
         return HoloOverlay(
-          height: theme.itemExtent,
-          color: theme.overlayColor,
+          height: widget.theme.itemExtent,
+          color: widget.theme.overlayColor,
         );
       case ScrollWheelDatePickerOverlay.line:
         return LineOverlay(
-          height: theme.itemExtent,
-          color: theme.overlayColor,
+          height: widget.theme.itemExtent,
+          color: widget.theme.overlayColor,
         );
       default:
         return const SizedBox.shrink();
@@ -122,14 +142,14 @@ class ScrollWheelDatePicker extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    _dateController.changeMonthFormat(format: theme.monthFormat);
+    _dateController.changeMonthFormat(format: widget.theme.monthFormat);
 
     return Stack(
       alignment: Alignment.center,
       children: [
         _overlay(),
         SizedBox(
-          height: theme.wheelPickerHeight,
+          height: widget.theme.wheelPickerHeight,
           child: ShaderMask(
             shaderCallback: (bounds) {
               return const LinearGradient(
@@ -146,14 +166,14 @@ class ScrollWheelDatePicker extends StatelessWidget {
                 // Days
                 Expanded(
                   child: ListenableBuilder(
-                    listenable: _dateController,
+                    listenable:_dateController,
                     builder: (_, __) => _scrollWidget(
                       controller: _dateController.dayController,
                       controllerItemChanged: (value) {
                         _dateController.changeDay(day: value);
-                        onSelectedItemChanged?.call(_dateController.dateTime);
+                        widget.onSelectedItemChanged?.call(_dateController.dateTime);
                       },
-                      looping: loopDays,
+                      looping: widget.loopDays,
                     ),
                   ),
                 ),
@@ -164,9 +184,9 @@ class ScrollWheelDatePicker extends StatelessWidget {
                     controller: _dateController.monthController,
                     controllerItemChanged: (value) {
                       _dateController.changeMonth(month: value);
-                      onSelectedItemChanged?.call(_dateController.dateTime);
+                      widget.onSelectedItemChanged?.call(_dateController.dateTime);
                     },
-                    looping: loopMonths,
+                    looping: widget.loopMonths,
                   ),
                 ),
 
@@ -176,16 +196,16 @@ class ScrollWheelDatePicker extends StatelessWidget {
                     controller: _dateController.yearController,
                     controllerItemChanged: (value) {
                       _dateController.changeYear(year: value);
-                      onSelectedItemChanged?.call(_dateController.dateTime);
+                      widget.onSelectedItemChanged?.call(_dateController.dateTime);
                     },
-                    looping: loopYears,
+                    looping: widget.loopYears,
                   ),
                 ),
               ],
             ),
           ),
         ),
-        theme is FlatDatePickerTheme
+        widget.theme is FlatDatePickerTheme
             ? IgnorePointer(
                 child: SizedBox(
                   height: defaultWheelPickerHeight,
@@ -194,8 +214,8 @@ class ScrollWheelDatePicker extends StatelessWidget {
                       Expanded(
                         child: Container(
                           decoration: BoxDecoration(
-                            color: (theme as FlatDatePickerTheme).backgroundColor.withOpacity(
-                                  1.0 - theme.overAndUnderCenterOpacity.clamp(0.0, 1.0),
+                            color: (widget.theme as FlatDatePickerTheme).backgroundColor.withOpacity(
+                                  1.0 - widget.theme.overAndUnderCenterOpacity.clamp(0.0, 1.0),
                                 ),
                           ),
                         ),
@@ -204,8 +224,8 @@ class ScrollWheelDatePicker extends StatelessWidget {
                       Expanded(
                         child: Container(
                           decoration: BoxDecoration(
-                            color: (theme as FlatDatePickerTheme).backgroundColor.withOpacity(
-                                  1.0 - theme.overAndUnderCenterOpacity.clamp(0.0, 1.0),
+                            color: (widget.theme as FlatDatePickerTheme).backgroundColor.withOpacity(
+                                  1.0 - widget.theme.overAndUnderCenterOpacity.clamp(0.0, 1.0),
                                 ),
                           ),
                         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -67,6 +67,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -79,34 +103,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -168,14 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "13.0.0"
 sdks:
   dart: ">=3.2.5 <4.0.0"
   flutter: ">=1.17.0"


### PR DESCRIPTION
When setState is called within a parent widget of the ScrollWheelDatePicker widget, the DateController is reinitialized, leading to the override of the current DateTime and an unsynced UI. This issue arises, for instance, when setState is invoked inside the onSelectedItemChanged callback. Consequently, the widget undergoes partial rebuilding, triggering a new initialization of the DateController.

```dart
/// initialDate = 1.1.1990
/// For example, if the date is initially set to 1.1.1990 and the year is increased by one, the resulting date should be 1.1.1991.
onSelectedItemChanged: (date) {
    setState(() {
        _myDateVariable = date;
    });
    print(date);
},

/// However, if we subsequently change the day (or month in this case) by incrementing it by one, the date becomes 1.2.1990 instead of 1.2.1991.

```
**Additional Changes:**

Removed the default text color to allow the utilization of the default color from the app theme.