### PR TITLE
Bug Fix:  Bug when setting initialDate to December in ScrollWheelDatePicker

### DIFF
--- a/example/lib/src/widgets/flat_holo_date_picker.dart
+++ b/example/lib/src/widgets/flat_holo_date_picker.dart
@@ -24,7 +24,8 @@ class FlatHoloDatePicker extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
           child: ScrollWheelDatePicker(
-            startDate: DateTime(2024, 5, 18),
+            startDate: DateTime(2020, 5, 18),
+            initialDate: DateTime(2024, 12, 25),
             theme: FlatDatePickerTheme(
               backgroundColor: Colors.white,
               overlay: ScrollWheelDatePickerOverlay.holo,

--- a/lib/src/date_controller.dart
+++ b/lib/src/date_controller.dart
@@ -58,7 +58,7 @@ class DateController with ChangeNotifier {
       selectedIndex: initialDate != null ? initialDate.day - 1 : null,
       numberOfDays: _getNumberOfDays(
         year: initialDate?.year ?? DateTime.now().year,
-        month: initialDate?.month ?? DateTime.now().month,
+        month: (initialDate != null) ? initialDate.month - 1 : DateTime.now().month - 1,
       ),
     );
 
@@ -230,7 +230,9 @@ class DateController with ChangeNotifier {
 
     _dayController = _dayController.copyWith(selectedIndex: selectedIndex, numberOfDays: numberOfDays);
 
-    notifyListeners();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      notifyListeners();
+    });
   }
 
   /// Called when the [initialDate] of the [ScrollWheelDatePicker] changed.


### PR DESCRIPTION
Fixes #9 

### Problem
When setting `initialDate` to a date in December, the `ScrollWheelDatePicker` throws an error due to state changes being triggered during the widget's build phase. This issue occurs because the `DateController` calls `notifyListeners` directly during initialization.

### Solution
- Added a `WidgetsBinding.instance.addPostFrameCallback` to delay `notifyListeners` until after the current frame is built. This prevents the error caused by state changes during the build phase.
- Updated `_dayController` initialization to properly handle the month value, ensuring December (month 12) is processed correctly.

### Impact
- Fixes the crash when `initialDate` is set to December.
- Improves stability by ensuring `notifyListeners` is only called after the build phase is complete.
- No breaking changes for existing implementations.

### Code Changes
#### Before (causing the error):
```dart
_dayController = _DayController(
  selectedIndex: initialDate != null ? initialDate.day - 1 : null,
  numberOfDays: _getNumberOfDays(
    year: initialDate?.year ?? DateTime.now().year,
    month: initialDate?.month ?? DateTime.now().month,
  ),
);

  void _updateNumberOfDays() {
    final int numberOfDays = _getNumberOfDays(year: _yearController.selectedIndex, month: _monthController.selectedIndex);

    final int selectedIndex = _dayController.selectedIndex >= numberOfDays ? numberOfDays - 1 : _dayController.selectedIndex;

    _dayController = _dayController.copyWith(selectedIndex: selectedIndex, numberOfDays: numberOfDays);

    notifyListeners();
  }

```

#### After fix

```dart
_dayController = _DayController(
  selectedIndex: initialDate != null ? initialDate.day - 1 : null,
  numberOfDays: _getNumberOfDays(
    year: initialDate?.year ?? DateTime.now().year,
    month: (initialDate != null) ? initialDate.month - 1 : DateTime.now().month - 1,
  ),
);


void _updateNumberOfDays() {
    final int numberOfDays = _getNumberOfDays(year: _yearController.selectedIndex, month: _monthController.selectedIndex);

    final int selectedIndex = _dayController.selectedIndex >= numberOfDays ? numberOfDays - 1 : _dayController.selectedIndex;

    _dayController = _dayController.copyWith(selectedIndex: selectedIndex, numberOfDays: numberOfDays);

    WidgetsBinding.instance.addPostFrameCallback((_) {
      notifyListeners();
    });
  }
 
```