### PR TITLE
chore: add dependabot configuration for example directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,14 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - Fingertips18
+
+  - package-ecosystem: "pub"
+    directory: /example
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 10
+    reviewers:
+      - Fingertips18


### PR DESCRIPTION
- Added a new Dependabot section specifically for the example directory.
- Ensures that dependencies in the example directory are monitored and kept up-to-date.
- Facilitates easier maintenance and compatibility for example-related dependencies.